### PR TITLE
Add zarr-based data pipeline and integrate into training

### DIFF
--- a/configs/data/zarr_data.yaml
+++ b/configs/data/zarr_data.yaml
@@ -1,0 +1,72 @@
+_target_: src.zarr_data.data_module.ZarrDataModule
+
+# Root folder that contains <dataset_name>/<filename>
+data_root: ${paths.data_dir}
+
+# Dataset folder name and zarr file name
+# Override these from the command line for your dataset.
+dataset_name: ERA5_IMERG_Med_192x192_2000-2024
+filename: data.zarr
+val_filename: null
+
+# Optional dataset names used to fit transforms (defaults to dataset_name)
+model_src_dataset_name: UKCP_Local
+input_transform_dataset_name: UKCP_Local
+transform_dir: null
+
+batch_size: 4
+num_workers: 0
+prefetch_factor: null
+shuffle: true
+random_flip: false
+
+# If true, append time channels to inputs
+include_time_inputs: ${time_inputs}
+evaluation: false
+
+# Config fields used by transforms
+predictands:
+  variables: ["precipitation"]
+  target_transform_keys: ["sqrturrecen"]
+
+predictors:
+  variables:
+    - specHum850
+    - specHum700
+    - specHum500
+    - specHum250
+    - temp850
+    - temp700
+    - temp500
+    - temp250
+    - vort850
+    - vort700
+    - vort500
+    - vort250
+    - mslp
+    - elevation
+  input_transform_keys:
+    - stan
+    - stan
+    - stan
+    - stan
+    - stan
+    - stan
+    - stan
+    - stan
+    - stan
+    - stan
+    - stan
+    - stan
+    - stan
+    - mm
+
+# Extra data settings aligned with the provided example config
+image_size: 192
+uniform_dequantization: false
+input_transform_key: stan
+target_transform_key: sqrturrecen
+input_transform_dataset: ""
+
+# Example overrides / flags
+time_inputs: false

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -4,7 +4,7 @@
 # order of defaults determines the order in which configs override each other
 defaults:
   - _self_
-  - data: downscaling.yaml
+  - data: zarr_data.yaml
   - model: null
   - callbacks: default.yaml
   - logger: null # set logger here or use command line (e.g. `python train.py logger=tensorboard`)

--- a/src/models/ae_module.py
+++ b/src/models/ae_module.py
@@ -117,7 +117,14 @@ class AutoencoderKL(LightningModule):
         }
     
     def preprocess_batch(self, batch):
-        (low_res, high_res, smt) = batch
+        if len(batch) >= 3:
+            low_res, high_res, third = batch[0], batch[1], batch[2]
+            smt = third if torch.is_tensor(third) and third.ndim >= 3 else None
+        elif len(batch) == 2:
+            low_res, high_res = batch
+            smt = None
+        else:
+            raise ValueError("Expected batch with at least 2 elements (low_res, high_res).")
         if self.ae_flag is None:
             return low_res, high_res
         elif self.ae_flag == 'residual':
@@ -125,6 +132,8 @@ class AutoencoderKL(LightningModule):
             if low_res.shape[-2::] != high_res.shape[-2::]:
                 # Assuming you are running an ldm and therefore passing low_res not interpolated
                 # and smt is static data: nearest-neighboring low-res and cat it to static data...')
+                if smt is None:
+                    smt = torch.zeros_like(low_res)
                 low_res = self.nn_lr_and_merge_with_static(low_res, smt)
             residual = high_res - self.unet(low_res)
             return residual, residual

--- a/src/models/ldm_module.py
+++ b/src/models/ldm_module.py
@@ -213,10 +213,19 @@ class LatentDiffusion(LightningModule):
         return self.p_losses(x, t, *args, **kwargs)
 
     def shared_step(self, batch):
-        (x,y,z,ts) = batch      # low_res, high_res_target, static_hres, time
-        assert not torch.any(torch.isnan(x)).item(), 'low_res data has NaNs'
-        assert not torch.any(torch.isnan(y)).item(), 'high_res has NaNs'
-        assert not torch.any(torch.isnan(z)).item(), 'static has NaNs'
+        if len(batch) == 4:
+            x, y, z, ts = batch
+        elif len(batch) == 3:
+            x, y, third = batch
+            if torch.is_tensor(third) and third.ndim >= 3:
+                z, ts = third, None
+            else:
+                z, ts = torch.zeros_like(x), third
+        else:
+            raise ValueError("Expected batch with 3 or 4 elements for LDM training.")
+        assert not torch.any(torch.isnan(x)).item(), "low_res data has NaNs"
+        assert not torch.any(torch.isnan(y)).item(), "high_res has NaNs"
+        assert not torch.any(torch.isnan(z)).item(), "static has NaNs"
         if self.autoencoder.ae_flag == 'residual':
             residual, _ = self.autoencoder.preprocess_batch([x, y, z])
             y = self.autoencoder.encode(residual)[0]

--- a/src/zarr_data/__init__.py
+++ b/src/zarr_data/__init__.py
@@ -1,0 +1,5 @@
+"""Zarr-based data pipeline for DiffScaler."""
+
+from .data_module import ZarrDataModule
+
+__all__ = ["ZarrDataModule"]

--- a/src/zarr_data/collate_np.py
+++ b/src/zarr_data/collate_np.py
@@ -1,0 +1,201 @@
+import logging
+import os
+import time as clock
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from torchvision.transforms import functional as TF
+
+from .dataset import DownscalingDataset
+
+logger = logging.getLogger(__name__)
+
+
+class FastCollate:
+    """
+    New behaviour:
+      - Accepts input_transforms: dict(var -> transform_obj) or None
+      - Accepts target_transforms: dict(var -> transform_obj) or None
+      - If the batch items are dict-based (new dataset), stacks per-variable into (B,C,H,W)
+      - Applies per-variable transforms in a loop over variables (vectorized across batch).
+      - Falls back to old behaviour if batch entries are numpy arrays.
+    """
+
+    def __init__(
+        self,
+        input_transforms=None,
+        target_transforms=None,
+        time_range=None,
+        input_variable_order=None,
+        target_variable_order=None,
+        random_flip=False,
+    ):
+        self.input_transforms = input_transforms
+        self.target_transforms = target_transforms
+        self.time_range = time_range
+        self.input_variable_order = list(input_variable_order) if input_variable_order is not None else None
+        self.target_variable_order = list(target_variable_order) if target_variable_order is not None else None
+        self.random_flip = random_flip
+
+    def _apply_transform_safe(self, xfm, arr):
+        """
+        Try several common call patterns for saved transforms:
+          - xfm.transforms(np_array)
+          - xfm.transform(np_array)
+          - xfm(np_array)
+        Accepts arr shape (B,H,W) or (B,1,H,W) or (B,C,H,W). Returns numpy arr.
+        """
+        if xfm is None:
+            return arr
+        try:
+            if hasattr(xfm, "transforms") and callable(xfm.transforms):
+                out = xfm.transforms(arr)
+            elif hasattr(xfm, "transform") and callable(xfm.transform):
+                out = xfm.transform(arr)
+            elif callable(xfm):
+                out = xfm(arr)
+            else:
+                raise AttributeError("No callable transform found")
+        except Exception:
+            try:
+                arr_c = arr[:, None, ...] if arr.ndim == 3 else arr
+                if hasattr(xfm, "transforms") and callable(xfm.transforms):
+                    out = xfm.transforms(arr_c)
+                elif hasattr(xfm, "transform") and callable(xfm.transform):
+                    out = xfm.transform(arr_c)
+                else:
+                    out = xfm(arr_c)
+            except Exception:
+                logger.exception("Transform application failed; falling back to identity.")
+                return arr
+        if torch.is_tensor(out):
+            out = out.cpu().numpy()
+        else:
+            out = np.asarray(out)
+        if out.ndim == 4 and out.shape[1] == 1:
+            out = np.squeeze(out, axis=1)
+        return out.astype(np.float32)
+
+    def __call__(self, batch):
+        """
+        batch: list of (cond, targ, time)
+           cond/targ can be either:
+             - dict(var->np.array)  (new behavior)
+             - stacked numpy arrays (B,C,H,W) style returned by older dataset (legacy)
+        Returns:
+           conds (torch.Tensor), targs (torch.Tensor), times (np.array)
+        """
+        rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+        _ = rank
+        start_time = clock.time()
+
+        first_cond = batch[0][0]
+        if isinstance(first_cond, dict):
+            if self.input_variable_order is not None:
+                input_vars = list(self.input_variable_order)
+            elif self.input_transforms is not None:
+                input_vars = list(self.input_transforms.keys())
+            else:
+                input_vars = list(first_cond.keys())
+
+            if self.target_variable_order is not None:
+                target_vars = list(self.target_variable_order)
+            elif self.target_transforms is not None:
+                target_vars = list(self.target_transforms.keys())
+            else:
+                target_vars = list(batch[0][1].keys())
+
+            batch_size = len(batch)
+            channels_in = len(input_vars)
+            channels_out = len(target_vars)
+
+            sample_arr = np.asarray(first_cond[input_vars[0]])
+            if sample_arr.ndim == 2:
+                height, width = sample_arr.shape
+                conds = np.empty((batch_size, channels_in, height, width), dtype=np.float32)
+                targs = np.empty((batch_size, channels_out, height, width), dtype=np.float32)
+            elif sample_arr.ndim == 3:
+                ch = sample_arr.shape[0]
+                height, width = sample_arr.shape[1], sample_arr.shape[2]
+                conds = np.empty((batch_size, channels_in * ch, height, width), dtype=np.float32)
+                targs = np.empty((batch_size, channels_out * ch, height, width), dtype=np.float32)
+            else:
+                raise RuntimeError(f"Unexpected per-variable array ndim={sample_arr.ndim}")
+
+            for i, var in enumerate(input_vars):
+                var_stack = np.stack([np.asarray(b[0][var]) for b in batch], axis=0).astype(np.float32)
+                if var_stack.ndim == 4:
+                    ch_dim = var_stack.shape[1]
+                    conds[:, i * ch_dim : (i + 1) * ch_dim, :, :] = var_stack
+                else:
+                    conds[:, i, :, :] = var_stack
+
+            for j, var in enumerate(target_vars):
+                tvar_stack = np.stack([np.asarray(b[1][var]) for b in batch], axis=0).astype(np.float32)
+                if tvar_stack.ndim == 4:
+                    ch_dim = tvar_stack.shape[1]
+                    targs[:, j * ch_dim : (j + 1) * ch_dim, :, :] = tvar_stack
+                else:
+                    targs[:, j, :, :] = tvar_stack
+
+            _ = clock.time() - start_time
+
+            if self.input_transforms is not None:
+                for i, var in enumerate(input_vars):
+                    xfm = self.input_transforms.get(var)
+                    var_slice = conds[:, i, ...]
+                    transformed = self._apply_transform_safe(xfm, var_slice)
+                    if transformed.ndim == 3:
+                        conds[:, i, :, :] = transformed
+                    elif transformed.ndim == 4 and transformed.shape[1] == 1:
+                        conds[:, i, :, :] = np.squeeze(transformed, axis=1)
+                    else:
+                        if transformed.ndim == 4:
+                            ch = transformed.shape[1]
+                            conds[:, i : i + ch, :, :] = transformed
+                        else:
+                            raise RuntimeError(
+                                f"Unexpected transformed shape for input var {var}: {transformed.shape}"
+                            )
+
+            if self.target_transforms is not None:
+                for j, var in enumerate(target_vars):
+                    xfm = self.target_transforms.get(var)
+                    t_slice = targs[:, j, ...]
+                    transformed_t = self._apply_transform_safe(xfm, t_slice)
+                    if transformed_t.ndim == 3:
+                        targs[:, j, :, :] = transformed_t
+                    elif transformed_t.ndim == 4 and transformed_t.shape[1] == 1:
+                        targs[:, j, :, :] = np.squeeze(transformed_t, axis=1)
+                    else:
+                        if transformed_t.ndim == 4:
+                            ch = transformed_t.shape[1]
+                            targs[:, j : j + ch, :, :] = transformed_t
+                        else:
+                            raise RuntimeError(
+                                f"Unexpected transformed shape for target var {var}: {transformed_t.shape}"
+                            )
+
+            if self.time_range is not None:
+                times = np.array([b[2] for b in batch])
+                cond_time_torch = DownscalingDataset.time_to_tensor(times, conds.shape, self.time_range)
+                if cond_time_torch is not None:
+                    cond_time_np = cond_time_torch.numpy()
+                    conds = np.concatenate([conds, cond_time_np], axis=1)
+
+            conds_t = torch.from_numpy(conds)
+            targs_t = torch.from_numpy(targs)
+
+            if self.random_flip:
+                if torch.rand(1) < 0.5:
+                    conds_t = TF.hflip(conds_t)
+                    targs_t = TF.hflip(targs_t)
+                if torch.rand(1) < 0.5:
+                    conds_t = TF.vflip(conds_t)
+                    targs_t = TF.vflip(targs_t)
+
+            times = np.array([b[2] for b in batch])
+            return conds_t, targs_t, times
+
+        raise RuntimeError("Legacy numpy-array batching is not supported in the new zarr pipeline.")

--- a/src/zarr_data/data_module.py
+++ b/src/zarr_data/data_module.py
@@ -1,0 +1,183 @@
+import logging
+import multiprocessing as mp
+import os
+from typing import Optional
+
+import torch.distributed as dist
+from lightning import LightningDataModule
+from torch.utils.data import DataLoader
+
+from .collate_np import FastCollate
+from .data_utils import TIME_RANGE, _get_zarr_length, get_variables_per_var, is_main_process
+from .dataset import DownscalingDataset
+from .get_xr_dataset import get_xr_dataset
+
+logger = logging.getLogger(__name__)
+
+
+def _worker_init_fn(worker_id):
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+    os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+    os.environ.setdefault("MKL_NUM_THREADS", "1")
+
+
+ctx = mp.get_context("spawn")
+
+
+class ZarrDataModule(LightningDataModule):
+    def __init__(
+        self,
+        dataset_name: str,
+        filename: str,
+        val_filename: Optional[str] = None,
+        data_root: Optional[str] = None,
+        model_src_dataset_name: Optional[str] = None,
+        input_transform_dataset_name: Optional[str] = None,
+        transform_dir: Optional[str] = None,
+        batch_size: int = 1,
+        include_time_inputs: bool = True,
+        evaluation: bool = False,
+        shuffle: bool = True,
+        num_workers: int = 0,
+        prefetch_factor: Optional[int] = None,
+        predictors: Optional[object] = None,
+        predictands: Optional[object] = None,
+        random_flip: bool = False,
+    ):
+        super().__init__()
+        self.save_hyperparameters(logger=False)
+
+        self.time_range = TIME_RANGE if include_time_inputs else None
+        self.variables, self.target_variables = get_variables_per_var(self.hparams)
+        self.dl_kwargs = dict(
+            batch_size=self.hparams.batch_size,
+            shuffle=self.hparams.shuffle,
+            collate_fn=None,
+            num_workers=self.hparams.num_workers,
+            pin_memory=True,
+            persistent_workers=self.hparams.num_workers > 0,
+            drop_last=True,
+            worker_init_fn=_worker_init_fn,
+        )
+
+        if self.hparams.num_workers > 0:
+            self.dl_kwargs["multiprocessing_context"] = ctx
+            default_pf = 2
+            if self.hparams.prefetch_factor is None:
+                pf = default_pf
+            else:
+                try:
+                    pf = int(self.hparams.prefetch_factor)
+                    if pf <= 0:
+                        pf = default_pf
+                except Exception:
+                    pf = default_pf
+            self.dl_kwargs["prefetch_factor"] = pf
+
+        self.train_len = 0
+        self.val_len = 0
+        self.test_len = 0
+
+    def setup(self, stage=None):
+        if is_main_process():
+            logger.info("Setting up ZarrDataModule for stage=%s", stage)
+
+        model_src_dataset_name = self.hparams.model_src_dataset_name or self.hparams.dataset_name
+        input_transform_dataset_name = (
+            self.hparams.input_transform_dataset_name or self.hparams.dataset_name
+        )
+
+        if stage == "fit" or stage is None:
+            self.train_zarr_path, self.train_transforms, self.train_target_transforms = get_xr_dataset(
+                self.hparams.dataset_name,
+                model_src_dataset_name,
+                input_transform_dataset_name,
+                self.hparams,
+                self.hparams.transform_dir,
+                self.hparams.filename,
+                base_dir=self.hparams.data_root,
+            )
+            self.train_len = _get_zarr_length(self.train_zarr_path)
+
+            self.val_zarr_path, _, _ = get_xr_dataset(
+                self.hparams.dataset_name,
+                model_src_dataset_name,
+                input_transform_dataset_name,
+                self.hparams,
+                self.hparams.transform_dir,
+                self.hparams.val_filename or self.hparams.filename,
+                base_dir=self.hparams.data_root,
+            )
+            self.val_len = _get_zarr_length(self.val_zarr_path)
+
+            self.train_collate = FastCollate(
+                input_transforms=self.train_transforms,
+                target_transforms=self.train_target_transforms,
+                time_range=self.time_range,
+                random_flip=self.hparams.random_flip,
+            )
+            self.val_collate = FastCollate(
+                input_transforms=self.train_transforms,
+                target_transforms=self.train_target_transforms,
+                time_range=self.time_range,
+            )
+
+        if stage == "test" or stage is None:
+            self.test_zarr_path, self.test_transforms, self.test_target_transforms = get_xr_dataset(
+                self.hparams.dataset_name,
+                model_src_dataset_name,
+                input_transform_dataset_name,
+                self.hparams,
+                self.hparams.transform_dir,
+                self.hparams.filename,
+                evaluation=self.hparams.evaluation,
+                base_dir=self.hparams.data_root,
+            )
+            self.test_len = _get_zarr_length(self.test_zarr_path)
+
+            self.test_collate = FastCollate(
+                input_transforms=self.test_transforms,
+                target_transforms=self.test_target_transforms,
+                time_range=self.time_range,
+            )
+
+    def train_dataloader(self):
+        rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+        if is_main_process():
+            logger.info("Creating train dataloader (rank %d)", rank)
+        xr_dataset = DownscalingDataset(
+            self.train_zarr_path,
+            self.variables,
+            self.target_variables,
+            self.time_range,
+            self.train_len,
+        )
+        self.dl_kwargs["collate_fn"] = getattr(self, "train_collate", self.dl_kwargs.get("collate_fn"))
+        return DataLoader(xr_dataset, **self.dl_kwargs)
+
+    def val_dataloader(self):
+        xr_dataset = DownscalingDataset(
+            self.val_zarr_path,
+            self.variables,
+            self.target_variables,
+            self.time_range,
+            self.val_len,
+        )
+        self.dl_kwargs["shuffle"] = False
+        self.dl_kwargs["collate_fn"] = getattr(self, "val_collate", self.dl_kwargs.get("collate_fn"))
+        return DataLoader(xr_dataset, **self.dl_kwargs)
+
+    def test_dataloader(self):
+        if is_main_process():
+            logger.info("Creating test dataloader")
+        xr_dataset = DownscalingDataset(
+            self.test_zarr_path,
+            self.variables,
+            self.target_variables,
+            self.time_range,
+            self.test_len,
+        )
+        self.dl_kwargs["num_workers"] = 0
+        self.dl_kwargs["shuffle"] = False
+        self.dl_kwargs["collate_fn"] = getattr(self, "test_collate", self.dl_kwargs.get("collate_fn"))
+        return DataLoader(xr_dataset, **self.dl_kwargs)

--- a/src/zarr_data/data_utils.py
+++ b/src/zarr_data/data_utils.py
@@ -1,0 +1,151 @@
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Union
+
+import numpy as np
+import pandas as pd
+import torch.distributed as dist
+import xarray as xr
+
+# =====================================================================
+
+def is_main_process():
+    return not dist.is_available() or not dist.is_initialized() or dist.get_rank() == 0
+
+
+def _data_config(config):
+    return getattr(config, "data", config)
+
+
+def dataset_path(dataset: str, base_dir: str = None) -> Path:
+    if base_dir is None:
+        base_dir = os.getenv("DERIVED_DATA", None)
+    if base_dir is None:
+        raise ValueError("base_dir must be provided or DERIVED_DATA must be set")
+    return Path(base_dir, dataset)
+
+
+def datafile_path(dataset: str, filename: str, base_dir: str = None) -> Path:
+    return dataset_path(dataset, base_dir=base_dir) / filename
+
+
+def open_zarr(dataset_name: str, filename: str, base_dir: str = None):
+    path = datafile_path(dataset_name, filename, base_dir=base_dir)
+    try:
+        return xr.open_zarr(path, consolidated=True)
+    except KeyError:
+        return xr.open_zarr(path)
+
+
+def get_variables_per_var(config):
+    cfg = _data_config(config)
+    variables = cfg.predictors.variables
+    target_variables = cfg.predictands.variables
+    return variables, target_variables
+
+
+def generate_output_filepath(output_dirpath):
+    output_dir = Path(output_dirpath)
+    if not output_dir.exists():
+        raise FileNotFoundError(f"The directory {output_dirpath} does not exist.")
+    nc_files = list(output_dir.glob("*.nc"))
+    count = len(nc_files)
+    output_filepath = os.path.join(output_dir, f"predictions-{count}.nc")
+    return output_filepath
+
+
+TIME_RANGE = (
+    datetime(2000, 6, 1),
+    datetime(2024, 11, 30),
+)
+
+
+def _get_zarr_length(zarr_path):
+    try:
+        ds = xr.open_zarr(zarr_path, consolidated=True)
+    except KeyError:
+        ds = xr.open_zarr(zarr_path)
+    n = len(ds.time)
+    try:
+        ds.close()
+    except Exception:
+        pass
+    return n
+
+
+def _parse_cf_time_units(units: str):
+    if not isinstance(units, str):
+        raise ValueError("units must be a string (CF 'units' attribute).")
+    match = re.match(r"\s*(\w+)\s+since\s+(.+)", units, flags=re.IGNORECASE)
+    if not match:
+        raise ValueError(f"Unrecognized CF units string: {units!r}")
+    unit = match.group(1).lower()
+    origin_str = match.group(2).strip()
+    unit_map = {
+        "sec": "seconds",
+        "second": "seconds",
+        "seconds": "seconds",
+        "min": "minutes",
+        "minute": "minutes",
+        "minutes": "minutes",
+        "hour": "hours",
+        "hours": "hours",
+        "day": "days",
+        "days": "days",
+    }
+    if unit not in unit_map:
+        raise ValueError(f"Unsupported time unit '{unit}' in units '{units}'")
+    return unit_map[unit], origin_str
+
+
+def decode_zarr_time_array(
+    z_or_array,
+    time_key: str = "time",
+    prefer_numpy_datetime: bool = True,
+) -> Union[np.ndarray, pd.DatetimeIndex]:
+    is_group = hasattr(z_or_array, "array_keys") and callable(z_or_array.array_keys)
+
+    if is_group:
+        if time_key not in z_or_array.array_keys():
+            raise KeyError(
+                f"time key '{time_key}' not found in Zarr group keys: {list(z_or_array.array_keys())}"
+            )
+        arr = z_or_array[time_key]
+    else:
+        arr = z_or_array
+
+    vals = arr[:]
+    if np.issubdtype(vals.dtype, np.datetime64):
+        return vals.astype("datetime64[ns]")
+
+    attrs = getattr(arr, "attrs", {}) or {}
+    if "units" not in attrs:
+        raise ValueError(
+            "Zarr time array missing 'units' attribute. "
+            "Either open with xarray (xr.open_zarr) or ensure 'units' present in Zarr attrs."
+        )
+
+    units = attrs["units"]
+    calendar = attrs.get("calendar", "standard").lower()
+
+    unit, origin_str = _parse_cf_time_units(units)
+
+    if calendar in ("standard", "gregorian", "proleptic_gregorian"):
+        origin_ts = pd.to_datetime(origin_str)
+        pandas_unit_map = {"seconds": "s", "minutes": "m", "hours": "h", "days": "D"}
+        if unit not in pandas_unit_map:
+            raise ValueError(f"Unit '{unit}' not supported for pandas path.")
+        td = pd.to_timedelta(vals, unit=pandas_unit_map[unit])
+        dtindex = origin_ts + td
+        if prefer_numpy_datetime:
+            return dtindex.values.astype("datetime64[ns]")
+        return dtindex
+
+    import cftime
+
+    flat_vals = np.array(vals).ravel().tolist()
+    dt_objs = cftime.num2date(flat_vals, units, calendar=calendar)
+    dt_arr = np.asarray(dt_objs, dtype=object).reshape(vals.shape)
+    return dt_arr

--- a/src/zarr_data/dataset.py
+++ b/src/zarr_data/dataset.py
@@ -1,0 +1,72 @@
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+import zarr
+
+from .data_utils import decode_zarr_time_array
+
+
+class DownscalingDataset(Dataset):
+    def __init__(self, file_path, variables, target_variables, time_range, length):
+        self.file_path = str(file_path)
+        self.variables = list(variables)
+        self.target_variables = list(target_variables)
+        self.time_range = time_range
+        self.length = length
+
+        self.opened = False
+
+    def _ensure_open(self):
+        if self.opened:
+            return
+        try:
+            self.z = zarr.open_consolidated(self.file_path)
+        except KeyError:
+            self.z = zarr.open(self.file_path)
+
+        self.var_arrays = {v: self.z[v] for v in self.variables}
+        self.target_arrays = {v: self.z[v] for v in self.target_variables}
+
+        if "time" in self.z.array_keys():
+            self.time_values = decode_zarr_time_array(self.z, time_key="time")
+        else:
+            self.time_values = None
+
+        self.opened = True
+
+    def __len__(self):
+        return self.length
+
+    def __getitem__(self, idx):
+        self._ensure_open()
+
+        cond = {v: np.asarray(self.var_arrays[v][idx]).astype("float32") for v in self.variables}
+        target = {
+            v: np.asarray(self.target_arrays[v][idx]).astype("float32")
+            for v in self.target_variables
+        }
+
+        time_value = self.time_values[idx] if self.time_values is not None else None
+        return cond, target, time_value
+
+    @staticmethod
+    def np_to_tensor(arr):
+        return torch.tensor(arr, dtype=torch.float32)
+
+    @staticmethod
+    def time_to_tensor(time_values, batch_shape, time_range):
+        if time_values is None:
+            return None
+        batch = batch_shape[0]
+        height = batch_shape[-2]
+        width = batch_shape[-1]
+        start = np.datetime64(time_range[0])
+        end = np.datetime64(time_range[1])
+        delta_days = (end - start) / np.timedelta64(1, "D")
+        climate_time = ((time_values - start) / np.timedelta64(1, "D")) / delta_days
+        climate_ch = np.broadcast_to(climate_time.reshape(batch, 1, 1), (batch, 1, height, width))
+        doy = (time_values.astype("datetime64[D]").view("int64") % 365) / 360.0
+        sin_ch = np.broadcast_to(np.sin(2 * np.pi * doy).reshape(batch, 1, 1), (batch, 1, height, width))
+        cos_ch = np.broadcast_to(np.cos(2 * np.pi * doy).reshape(batch, 1, 1), (batch, 1, height, width))
+        out_np = np.concatenate([climate_ch, sin_ch, cos_ch], axis=1)
+        return torch.tensor(out_np, dtype=torch.float32)

--- a/src/zarr_data/get_xr_dataset.py
+++ b/src/zarr_data/get_xr_dataset.py
@@ -1,0 +1,38 @@
+import logging
+
+import torch.distributed as dist
+
+from .data_utils import datafile_path, is_main_process
+from .transforms_np import _find_or_create_transforms_per_variable_from_config
+
+logger = logging.getLogger(__name__)
+
+
+def get_xr_dataset(
+    active_dataset_name,
+    model_src_dataset_name,
+    input_transform_dataset_name,
+    config,
+    transform_dir,
+    filename,
+    evaluation=False,
+    base_dir=None,
+):
+    rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+    if is_main_process():
+        logger.info("Getting zarr dataset (rank %d)", rank)
+
+    input_transforms, target_transforms = _find_or_create_transforms_per_variable_from_config(
+        filename,
+        input_transform_dataset_name,
+        model_src_dataset_name,
+        transform_dir,
+        config,
+        evaluation,
+        base_dir,
+    )
+
+    zarr_path = datafile_path(active_dataset_name, filename, base_dir=base_dir)
+    if is_main_process():
+        logger.info("get_xr_dataset returning path: %s", zarr_path)
+    return zarr_path, input_transforms, target_transforms

--- a/src/zarr_data/transforms_np.py
+++ b/src/zarr_data/transforms_np.py
@@ -1,0 +1,965 @@
+import gc
+import logging
+import os
+import pickle
+import time
+from typing import Any, Dict, Iterable, List
+
+import numpy as np
+
+from .data_utils import open_zarr
+from .utils import input_to_list
+
+logger = logging.getLogger(__name__)
+
+
+# -----------------------
+# save / load transforms
+# -----------------------
+
+def save_transform(xfm, path: str):
+    with open(path, "wb") as f:
+        logger.info("Storing transform: %s", path)
+        pickle.dump(xfm, f, pickle.HIGHEST_PROTOCOL)
+
+
+def load_transform(path: str):
+    with open(path, "rb") as f:
+        logger.info("Using stored transform: %s", path)
+        xfm = pickle.load(f)
+    return xfm
+
+
+# -----------------------
+# helpers for numpy-array friendly transforms
+# -----------------------
+
+def _is_numpy_array(x):
+    return isinstance(x, np.ndarray)
+
+
+def _array_channel_info(arr: np.ndarray, variables: Iterable[str]):
+    if not _is_numpy_array(arr):
+        raise TypeError("arr must be numpy.ndarray")
+    variables_list = list(variables)
+    channels = len(variables_list)
+
+    if arr.ndim >= 3 and arr.shape[1] == channels:
+        return arr, True, variables_list
+    if arr.ndim >= 2 and arr.shape[0] == channels:
+        return arr[np.newaxis, ...], False, variables_list
+
+    if arr.shape[0] == channels:
+        return arr[np.newaxis, ...], False, variables_list
+
+    raise ValueError(
+        f"Could not interpret numpy array shape {arr.shape} as channel-first for {channels} variables"
+    )
+
+
+def _stack_param_dict_to_array(param_dict: Dict[str, Any], variables: List[str]) -> np.ndarray:
+    elems = []
+    for var in variables:
+        elems.append(np.asarray(param_dict[var]))
+    return np.stack(elems, axis=0)
+
+
+def _param_broadcast_for_arr(param_stack: np.ndarray, arr_cf: np.ndarray) -> np.ndarray:
+    spatial_ndim = arr_cf.ndim - 2
+    channels = param_stack.shape[0]
+
+    if param_stack.ndim == 1:
+        target_shape = (1, channels) + (1,) * spatial_ndim
+        reshaped = param_stack.reshape(target_shape)
+        return np.broadcast_to(reshaped, arr_cf.shape)
+
+    if param_stack.ndim - 1 != spatial_ndim:
+        pad = spatial_ndim - (param_stack.ndim - 1)
+        if pad < 0:
+            raise ValueError("Parameter spatial dims bigger than array spatial dims")
+        reshaped = param_stack.reshape((1,) + param_stack.shape + (1,) * pad)
+        return np.broadcast_to(reshaped, arr_cf.shape)
+
+    reshaped = param_stack.reshape((1,) + param_stack.shape)
+    return np.broadcast_to(reshaped, arr_cf.shape)
+
+
+# -----------------------
+# find and build transforms
+# -----------------------
+
+def _build_transform(filename, variables, active_dataset_name, model_src_dataset_name, transform_keys, builder, base_dir):
+    logger.info("Fitting transform for variables: %s", variables)
+    xfm = builder(variables, transform_keys)
+    model_src_ds = open_zarr(model_src_dataset_name, filename, base_dir=base_dir)
+    active_ds = open_zarr(active_dataset_name, filename, base_dir=base_dir)
+    try:
+        model_src_np = _ensure_numpy_dict(model_src_ds, variables)
+        active_np = _ensure_numpy_dict(active_ds, variables)
+        xfm.fit(active_np, model_src_np)
+    finally:
+        _close_dataset_if_possible(model_src_ds)
+        _close_dataset_if_possible(active_ds)
+        del model_src_np, active_np, model_src_ds, active_ds
+        gc.collect()
+    return xfm
+
+
+def _find_or_create_transforms(
+    filename,
+    active_dataset_name,
+    model_src_dataset_name,
+    transform_dir,
+    input_transform_key,
+    target_transform_key,
+    evaluation,
+    variables,
+    target_variables,
+    base_dir,
+):
+    logger.info("Finding or creating transforms for %s", active_dataset_name)
+
+    if transform_dir is None:
+        input_transform = _build_transform(
+            filename,
+            variables,
+            active_dataset_name,
+            model_src_dataset_name,
+            input_transform_key,
+            build_input_transform,
+            base_dir,
+        )
+        if evaluation:
+            raise RuntimeError("Target transform should only be fitted during training")
+        target_transform = _build_transform(
+            filename,
+            target_variables,
+            active_dataset_name,
+            model_src_dataset_name,
+            target_transform_key,
+            build_target_transform,
+            base_dir,
+        )
+    else:
+        dataset_transform_dir = os.path.join(
+            transform_dir, active_dataset_name, f"{input_transform_key}-{target_transform_key}"
+        )
+        os.makedirs(dataset_transform_dir, exist_ok=True)
+        input_transform_path = os.path.join(dataset_transform_dir, "input.pickle")
+        target_transform_path = os.path.join(dataset_transform_dir, "target.pickle")
+
+        if os.path.exists(input_transform_path):
+            start_time = time.time()
+            input_transform = load_transform(input_transform_path)
+            logger.info("Loaded input_transform in %.4f seconds", time.time() - start_time)
+        else:
+            start_time = time.time()
+            input_transform = _build_transform(
+                filename,
+                variables,
+                active_dataset_name,
+                model_src_dataset_name,
+                input_transform_key,
+                build_input_transform,
+                base_dir,
+            )
+            logger.info("Built input_transform in %.4f seconds", time.time() - start_time)
+            save_transform(input_transform, input_transform_path)
+
+        if os.path.exists(target_transform_path):
+            start_time = time.time()
+            target_transform = load_transform(target_transform_path)
+            logger.info("Loaded target_transform in %.4f seconds", time.time() - start_time)
+        else:
+            if evaluation:
+                raise RuntimeError("Target transform should only be fitted during training")
+            start_time = time.time()
+            target_transform = _build_transform(
+                filename,
+                target_variables,
+                active_dataset_name,
+                model_src_dataset_name,
+                target_transform_key,
+                build_target_transform,
+                base_dir,
+            )
+            logger.info("Built target_transform in %.4f seconds", time.time() - start_time)
+            save_transform(target_transform, target_transform_path)
+
+    gc.collect()
+    return input_transform, target_transform
+
+
+def _build_transform_per_variable_from_config(
+    filename,
+    variables,
+    active_dataset_name,
+    model_src_dataset_name,
+    transform_keys_dict,
+    builder,
+    base_dir,
+):
+    model_src_ds = open_zarr(model_src_dataset_name, filename, base_dir=base_dir)
+    active_ds = open_zarr(active_dataset_name, filename, base_dir=base_dir)
+    transforms = {}
+    try:
+        model_src_np = _ensure_numpy_dict(model_src_ds, variables)
+        active_np = _ensure_numpy_dict(active_ds, variables)
+        for var in variables:
+            key = transform_keys_dict.get(var, "none")
+            xfm = builder([var], key)
+            xfm.fit({var: active_np[var]}, {var: model_src_np[var]})
+            transforms[var] = xfm
+    finally:
+        _close_dataset_if_possible(model_src_ds)
+        _close_dataset_if_possible(active_ds)
+        del model_src_np, active_np, model_src_ds, active_ds
+        gc.collect()
+    return transforms
+
+
+def _find_or_create_transforms_per_variable_from_config(
+    filename,
+    active_dataset_name,
+    model_src_dataset_name,
+    transform_dir,
+    config,
+    evaluation,
+    base_dir,
+):
+    cfg = getattr(config, "data", config)
+    input_vars = cfg.predictors.variables
+    input_keys = cfg.predictors.input_transform_keys
+    input_transform_keys_dict = dict(zip(input_vars, input_keys))
+
+    target_vars = cfg.predictands.variables
+    target_keys = cfg.predictands.target_transform_keys
+    target_transform_keys_dict = dict(zip(target_vars, target_keys))
+
+    input_transforms = {}
+    target_transforms = {}
+
+    if transform_dir is None:
+        transform_dir = os.path.join(base_dir or ".", "transforms")
+
+    dataset_transform_dir = os.path.join(transform_dir, active_dataset_name)
+    os.makedirs(dataset_transform_dir, exist_ok=True)
+
+    for var in input_vars:
+        input_transform_path = os.path.join(
+            dataset_transform_dir, f"input_{var}_{input_transform_keys_dict[var]}.pickle"
+        )
+        if os.path.exists(input_transform_path):
+            input_transforms[var] = load_transform(input_transform_path)
+        else:
+            xfm = _build_transform_per_variable_from_config(
+                filename,
+                [var],
+                active_dataset_name,
+                model_src_dataset_name,
+                input_transform_keys_dict,
+                build_input_transform,
+                base_dir,
+            )[var]
+            save_transform(xfm, input_transform_path)
+            input_transforms[var] = xfm
+
+    if evaluation and target_vars:
+        raise RuntimeError("Target transform should only be fitted during training")
+
+    for var in target_vars:
+        target_transform_path = os.path.join(
+            dataset_transform_dir, f"target_{var}_{target_transform_keys_dict[var]}.pickle"
+        )
+        if os.path.exists(target_transform_path):
+            target_transforms[var] = load_transform(target_transform_path)
+        else:
+            xfm = _build_transform_per_variable_from_config(
+                filename,
+                [var],
+                active_dataset_name,
+                model_src_dataset_name,
+                target_transform_keys_dict,
+                build_target_transform,
+                base_dir,
+            )[var]
+            save_transform(xfm, target_transform_path)
+            target_transforms[var] = xfm
+
+    gc.collect()
+    return input_transforms, target_transforms
+
+
+# -----------------------
+# registration utilities
+# -----------------------
+
+_XFMS = {}
+
+
+def register_transform(cls=None, *, name=None):
+    def _register(cls):
+        local_name = cls.__name__ if name is None else name
+        if local_name in _XFMS:
+            raise ValueError(f"Already registered transform with name: {local_name}")
+        _XFMS[local_name] = cls
+        return cls
+
+    if cls is None:
+        return _register
+    return _register(cls)
+
+
+def get_transform(name: str):
+    return _XFMS[name]
+
+
+# -----------------------
+# helpers: convert datasets to numpy dicts and axis mapping
+# -----------------------
+
+def _ensure_numpy_dict(ds: Any, variables: Iterable[str] = None) -> Dict[str, np.ndarray]:
+    out = {}
+    if isinstance(ds, dict):
+        for key, value in ds.items():
+            if variables is None or key in set(variables):
+                out[key] = np.asarray(value)
+        return out
+    vars_to_read = variables
+    if vars_to_read is None:
+        try:
+            vars_to_read = list(ds.data_vars)
+        except Exception:
+            try:
+                vars_to_read = list(ds.keys())
+            except Exception:
+                raise RuntimeError(
+                    "Could not determine variable names from dataset. Provide 'variables' list."
+                )
+    for var in vars_to_read:
+        try:
+            val = ds[var].values
+        except Exception:
+            try:
+                val = np.asarray(ds[var])
+            except Exception as exc:
+                raise RuntimeError(f"Cannot convert variable {var} to numpy array.") from exc
+        out[var] = np.asarray(val)
+    return out
+
+
+def _close_dataset_if_possible(ds: Any):
+    try:
+        if hasattr(ds, "close"):
+            ds.close()
+    except Exception:
+        pass
+
+
+def _dim_index_map_for_ndim(ndim: int) -> Dict[str, int]:
+    if ndim == 4:
+        return {
+            "time": 0,
+            "ensemble": 1,
+            "ensemble_member": 1,
+            "lat": 2,
+            "latitude": 2,
+            "lon": 3,
+            "longitude": 3,
+        }
+    if ndim == 3:
+        return {"time": 0, "lat": 1, "latitude": 1, "lon": 2, "longitude": 2}
+    if ndim == 2:
+        return {"lat": 0, "latitude": 0, "lon": 1, "longitude": 1}
+    return {"time": 0}
+
+
+def _axes_for_dims(arr: np.ndarray, dims: Iterable[str]) -> List[int]:
+    mapping = _dim_index_map_for_ndim(arr.ndim)
+    axes = []
+    for dim in dims:
+        if dim in mapping:
+            axes.append(mapping[dim])
+    axes = sorted(set(axes))
+    return axes
+
+
+def _maybe_reduce(arr: np.ndarray, dims: Iterable[str]):
+    axes = _axes_for_dims(arr, dims)
+    if len(axes) == 0:
+        return arr
+    axes_tuple = tuple(axes) if len(axes) > 1 else axes[0]
+    return axes_tuple, axes
+
+
+# -----------------------
+# Transform classes (NumPy-based)
+# -----------------------
+
+class CropT:
+    def __init__(self, size: int):
+        self.size = size
+
+    def fit(self, target_ds, model_src_ds):
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            out = {}
+            for var, arr_v in _ensure_numpy_dict(arr).items():
+                if arr_v.ndim >= 2:
+                    out[var] = arr_v[..., : self.size, : self.size]
+                else:
+                    out[var] = arr_v
+            return out
+        arr_cf, had_batch, _ = _array_channel_info(arr, ["dummy"])
+        out = arr_cf[..., : self.size, : self.size]
+        return out if had_batch else out[0]
+
+
+@register_transform(name="stan")
+class Standardize:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, model_src_ds):
+        t = _ensure_numpy_dict(target_ds, self.variables)
+        self.means = {var: np.mean(t[var]) for var in self.variables}
+        self.stds = {var: np.std(t[var]) for var in self.variables}
+        for var in self.variables:
+            if self.stds[var] == 0:
+                self.stds[var] = 1.0
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: (dsn[var] - self.means[var]) / self.stds[var] for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        means_stack = np.array([self.means[var] for var in self.variables])
+        stds_stack = np.array([self.stds[var] for var in self.variables])
+        means_b = _param_broadcast_for_arr(means_stack, arr_cf)
+        stds_b = _param_broadcast_for_arr(stds_stack, arr_cf)
+        out = (arr_cf - means_b) / stds_b
+        return out if had_batch else out[0]
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: dsn[var] * self.stds[var] + self.means[var] for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        means_stack = np.array([self.means[var] for var in self.variables])
+        stds_stack = np.array([self.stds[var] for var in self.variables])
+        means_b = _param_broadcast_for_arr(means_stack, arr_cf)
+        stds_b = _param_broadcast_for_arr(stds_stack, arr_cf)
+        out = arr_cf * stds_b + means_b
+        return out if had_batch else out[0]
+
+
+@register_transform(name="pixelstan")
+class PixelStandardize:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, model_src_ds):
+        t = _ensure_numpy_dict(target_ds, self.variables)
+        self.means = {}
+        self.stds = {}
+        for var in self.variables:
+            arr = t[var]
+            axes = _axes_for_dims(arr, ["time"])
+            if len(axes) == 0:
+                self.means[var] = np.asarray(arr)
+                self.stds[var] = np.asarray(arr)
+            else:
+                axes_tuple = tuple(axes) if len(axes) > 1 else axes[0]
+                self.means[var] = np.mean(arr, axis=axes_tuple)
+                self.stds[var] = np.std(arr, axis=axes_tuple)
+                self.stds[var] = np.where(self.stds[var] == 0, 1.0, self.stds[var])
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: (dsn[var] - self.means[var]) / self.stds[var] for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        means_stack = _stack_param_dict_to_array(self.means, self.variables)
+        stds_stack = _stack_param_dict_to_array(self.stds, self.variables)
+        means_b = _param_broadcast_for_arr(means_stack, arr_cf)
+        stds_b = _param_broadcast_for_arr(stds_stack, arr_cf)
+        out = (arr_cf - means_b) / stds_b
+        return out if had_batch else out[0]
+
+
+@register_transform(name="noop")
+class NoopT:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, model_src_ds):
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            return _ensure_numpy_dict(arr)
+        return arr
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            return _ensure_numpy_dict(arr)
+        return arr
+
+
+@register_transform(name="pixelmmsstan")
+class PixelMatchModelSrcStandardize:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, model_src_ds):
+        t = _ensure_numpy_dict(target_ds, self.variables)
+        m = _ensure_numpy_dict(model_src_ds, self.variables)
+        self.pixel_target_means = {}
+        self.pixel_target_stds = {}
+        self.pixel_model_src_means = {}
+        self.pixel_model_src_stds = {}
+        self.global_model_src_means = {}
+        self.global_model_src_stds = {}
+        for var in self.variables:
+            arr_t = t[var]
+            arr_m = m[var]
+            axes_t = _axes_for_dims(arr_t, ["time", "ensemble", "ensemble_member"])
+            axes_m = _axes_for_dims(arr_m, ["time", "ensemble", "ensemble_member"])
+            if len(axes_t) == 0:
+                self.pixel_target_means[var] = arr_t
+                self.pixel_target_stds[var] = arr_t
+            else:
+                axes_tuple_t = tuple(axes_t) if len(axes_t) > 1 else axes_t[0]
+                self.pixel_target_means[var] = np.mean(arr_t, axis=axes_tuple_t)
+                self.pixel_target_stds[var] = np.std(arr_t, axis=axes_tuple_t)
+                self.pixel_target_stds[var] = np.where(self.pixel_target_stds[var] == 0, 1.0, self.pixel_target_stds[var])
+            if len(axes_m) == 0:
+                self.pixel_model_src_means[var] = arr_m
+                self.pixel_model_src_stds[var] = arr_m
+            else:
+                axes_tuple_m = tuple(axes_m) if len(axes_m) > 1 else axes_m[0]
+                self.pixel_model_src_means[var] = np.mean(arr_m, axis=axes_tuple_m)
+                self.pixel_model_src_stds[var] = np.std(arr_m, axis=axes_tuple_m)
+                self.pixel_model_src_stds[var] = np.where(self.pixel_model_src_stds[var] == 0, 1.0, self.pixel_model_src_stds[var])
+            self.global_model_src_means[var] = np.mean(arr_m)
+            self.global_model_src_stds[var] = np.std(arr_m)
+            if self.global_model_src_stds[var] == 0:
+                self.global_model_src_stds[var] = 1.0
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {}
+            for var in self.variables:
+                arr_v = dsn[var]
+                da_pixel_stan = (arr_v - self.pixel_target_means[var]) / self.pixel_target_stds[var]
+                da_pixel_like_model_src = da_pixel_stan * self.pixel_model_src_stds[var] + self.pixel_model_src_means[var]
+                da_global_stan_like_model_src = (
+                    da_pixel_like_model_src - self.global_model_src_means[var]
+                ) / self.global_model_src_stds[var]
+                out[var] = da_global_stan_like_model_src
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        ptm = _stack_param_dict_to_array(self.pixel_target_means, self.variables)
+        pts = _stack_param_dict_to_array(self.pixel_target_stds, self.variables)
+        pmm = _stack_param_dict_to_array(self.pixel_model_src_means, self.variables)
+        pms = _stack_param_dict_to_array(self.pixel_model_src_stds, self.variables)
+        gmean = np.array([self.global_model_src_means[var] for var in self.variables])
+        gstd = np.array([self.global_model_src_stds[var] for var in self.variables])
+        ptm_b = _param_broadcast_for_arr(ptm, arr_cf)
+        pts_b = _param_broadcast_for_arr(pts, arr_cf)
+        pmm_b = _param_broadcast_for_arr(pmm, arr_cf)
+        pms_b = _param_broadcast_for_arr(pms, arr_cf)
+        gmean_b = _param_broadcast_for_arr(gmean, arr_cf)
+        gstd_b = _param_broadcast_for_arr(gstd, arr_cf)
+        da_pixel_stan = (arr_cf - ptm_b) / pts_b
+        da_pixel_like_model_src = da_pixel_stan * pms_b + pmm_b
+        da_global_stan_like_model_src = (da_pixel_like_model_src - gmean_b) / gstd_b
+        out = da_global_stan_like_model_src
+        return out if had_batch else out[0]
+
+
+@register_transform(name="mm")
+class MinMax:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, model_src_ds):
+        t = _ensure_numpy_dict(target_ds, self.variables)
+        self.maxs = {var: np.max(t[var]) for var in self.variables}
+        self.mins = {var: np.min(t[var]) for var in self.variables}
+        for var in self.variables:
+            if self.maxs[var] == self.mins[var]:
+                self.maxs[var] = self.mins[var] + 1.0
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: (dsn[var] - self.mins[var]) / (self.maxs[var] - self.mins[var]) for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        maxs_stack = np.array([self.maxs[var] for var in self.variables])
+        mins_stack = np.array([self.mins[var] for var in self.variables])
+        maxs_b = _param_broadcast_for_arr(maxs_stack, arr_cf)
+        mins_b = _param_broadcast_for_arr(mins_stack, arr_cf)
+        out = (arr_cf - mins_b) / (maxs_b - mins_b)
+        return out if had_batch else out[0]
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: dsn[var] * (self.maxs[var] - self.mins[var]) + self.mins[var] for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        maxs_stack = np.array([self.maxs[var] for var in self.variables])
+        mins_stack = np.array([self.mins[var] for var in self.variables])
+        maxs_b = _param_broadcast_for_arr(maxs_stack, arr_cf)
+        mins_b = _param_broadcast_for_arr(mins_stack, arr_cf)
+        out = arr_cf * (maxs_b - mins_b) + mins_b
+        return out if had_batch else out[0]
+
+
+@register_transform(name="ur")
+class UnitRangeT:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, model_src_ds):
+        t = _ensure_numpy_dict(target_ds, self.variables)
+        self.maxs = {var: np.max(t[var]) for var in self.variables}
+        for var in self.variables:
+            if self.maxs[var] == 0:
+                self.maxs[var] = 1.0
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: dsn[var] / self.maxs[var] for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        maxs_stack = np.array([self.maxs[var] for var in self.variables])
+        maxs_b = _param_broadcast_for_arr(maxs_stack, arr_cf)
+        out = arr_cf / maxs_b
+        return out if had_batch else out[0]
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: dsn[var] * self.maxs[var] for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        maxs_stack = np.array([self.maxs[var] for var in self.variables])
+        maxs_b = _param_broadcast_for_arr(maxs_stack, arr_cf)
+        out = arr_cf * maxs_b
+        return out if had_batch else out[0]
+
+
+@register_transform(name="clip")
+class ClipT:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, model_src_ds):
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            return _ensure_numpy_dict(arr)
+        return arr
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {}
+            for var in self.variables:
+                out[var] = np.clip(dsn[var], a_min=0.0, a_max=None)
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = np.clip(arr_cf, a_min=0.0, a_max=None)
+        return out if had_batch else out[0]
+
+
+@register_transform(name="pc")
+class PercentToPropT:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, _model_src_ds):
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: dsn[var] / 100.0 for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = arr_cf / 100.0
+        return out if had_batch else out[0]
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: dsn[var] * 100.0 for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = arr_cf * 100.0
+        return out if had_batch else out[0]
+
+
+@register_transform(name="recen")
+class RecentreT:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, model_src_ds):
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: (dsn[var] * 2.0 - 1.0) for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = arr_cf * 2.0 - 1.0
+        return out if had_batch else out[0]
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: (dsn[var] + 1.0) / 2.0 for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = (arr_cf + 1.0) / 2.0
+        return out if had_batch else out[0]
+
+
+@register_transform(name="sqrt")
+class SqrtT:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, model_src_ds):
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: np.power(dsn[var], 0.5) for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = np.power(arr_cf, 0.5)
+        return out if had_batch else out[0]
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: np.power(dsn[var], 2.0) for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = np.power(arr_cf, 2.0)
+        return out if had_batch else out[0]
+
+
+@register_transform(name="root")
+class RootT:
+    def __init__(self, variables: Iterable[str], root_base: float):
+        self.variables = input_to_list(variables)
+        self.root_base = root_base
+
+    def fit(self, target_ds, model_src_ds):
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: np.power(dsn[var], 1.0 / self.root_base) for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = np.power(arr_cf, 1.0 / self.root_base)
+        return out if had_batch else out[0]
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: np.power(dsn[var], self.root_base) for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = np.power(arr_cf, self.root_base)
+        return out if had_batch else out[0]
+
+
+@register_transform(name="rm")
+class RawMomentT:
+    def __init__(self, variables: Iterable[str], root_base: float):
+        self.variables = input_to_list(variables)
+        self.root_base = root_base
+
+    def fit(self, target_ds, model_src_ds):
+        t = _ensure_numpy_dict(target_ds, self.variables)
+        self.raw_moments = {
+            var: np.power(np.mean(np.power(t[var], self.root_base)), 1.0 / self.root_base)
+            for var in self.variables
+        }
+        for var in self.variables:
+            if self.raw_moments[var] == 0:
+                self.raw_moments[var] = 1.0
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: dsn[var] / self.raw_moments[var] for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        rm = np.array([self.raw_moments[var] for var in self.variables])
+        rm_b = _param_broadcast_for_arr(rm, arr_cf)
+        out = arr_cf / rm_b
+        return out if had_batch else out[0]
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: dsn[var] * self.raw_moments[var] for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        rm = np.array([self.raw_moments[var] for var in self.variables])
+        rm_b = _param_broadcast_for_arr(rm, arr_cf)
+        out = arr_cf * rm_b
+        return out if had_batch else out[0]
+
+
+@register_transform(name="log")
+class LogT:
+    def __init__(self, variables: Iterable[str]):
+        self.variables = input_to_list(variables)
+
+    def fit(self, target_ds, model_src_ds):
+        return self
+
+    def transform(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: np.log1p(dsn[var]) for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = np.log1p(arr_cf)
+        return out if had_batch else out[0]
+
+    def invert(self, arr, times=None):
+        if isinstance(arr, dict):
+            dsn = _ensure_numpy_dict(arr, self.variables)
+            out = {var: np.expm1(dsn[var]) for var in self.variables}
+            return {**dsn, **out}
+        arr_cf, had_batch, _ = _array_channel_info(arr, self.variables)
+        out = np.expm1(arr_cf)
+        return out if had_batch else out[0]
+
+
+@register_transform(name="compose")
+class ComposeT:
+    def __init__(self, transforms: Iterable[Any]):
+        self.transforms = list(transforms)
+
+    def fit(self, target_ds, model_src_ds=None):
+        current_target = target_ds
+        for transform in self.transforms:
+            transform.fit(current_target, model_src_ds)
+            current_target = transform.transform(current_target)
+        return self
+
+    def transform(self, arr, times=None):
+        current = arr
+        for transform in self.transforms:
+            try:
+                current = transform.transform(current, times=times)
+            except TypeError:
+                current = transform.transform(current)
+        return current
+
+    def invert(self, arr, times=None):
+        current = arr
+        for transform in reversed(self.transforms):
+            if hasattr(transform, "invert"):
+                try:
+                    current = transform.invert(current, times=times)
+                except TypeError:
+                    current = transform.invert(current)
+            else:
+                raise RuntimeError(f"Transform {transform} has no invert method")
+        return current
+
+
+# -----------------------
+# builders
+# -----------------------
+
+def build_input_transform(variables, key="v1"):
+    if key == "v1":
+        return ComposeT([Standardize(variables), UnitRangeT(variables)])
+    if key in ["none", "noop"]:
+        return NoopT(variables)
+    if key in ["standardize", "stan"]:
+        return ComposeT([Standardize(variables)])
+    if key == "stanur":
+        return ComposeT([Standardize(variables), UnitRangeT(variables)])
+    if key == "stanurrecen":
+        return ComposeT([Standardize(variables), UnitRangeT(variables), RecentreT(variables)])
+    if key == "pixelstan":
+        return ComposeT([PixelStandardize(variables)])
+    if key == "pixelmmsstan":
+        return ComposeT([PixelMatchModelSrcStandardize(variables)])
+    if key == "pixelmmsstanur":
+        return ComposeT([PixelMatchModelSrcStandardize(variables), UnitRangeT(variables)])
+    xfms = [get_transform(name)(variables) for name in key.split(";")]
+    return ComposeT(xfms)
+
+
+def build_target_transform(target_variable, key):
+    if key == "v1":
+        return ComposeT([SqrtT([target_variable]), ClipT([target_variable]), UnitRangeT([target_variable])])
+    if key in ["none", "noop"]:
+        return NoopT([target_variable])
+    if key == "sqrt":
+        return ComposeT([RootT([target_variable], 2), ClipT([target_variable])])
+    if key == "sqrtur":
+        return ComposeT([RootT([target_variable], 2), ClipT([target_variable]), UnitRangeT([target_variable])])
+    if key == "sqrturrecen":
+        return ComposeT(
+            [RootT([target_variable], 2), ClipT([target_variable]), UnitRangeT([target_variable]), RecentreT([target_variable])]
+        )
+    if key == "sqrtrm":
+        return ComposeT([RootT([target_variable], 2), RawMomentT([target_variable], 2), ClipT([target_variable])])
+    if key == "cbrt":
+        return ComposeT([RootT([target_variable], 3), ClipT([target_variable])])
+    if key == "cbrtur":
+        return ComposeT([RootT([target_variable], 3), ClipT([target_variable]), UnitRangeT([target_variable])])
+    if key == "qdrt":
+        return ComposeT([RootT([target_variable], 4), ClipT([target_variable])])
+    if key == "log":
+        return ComposeT([LogT([target_variable]), ClipT([target_variable])])
+    if key == "logurrecen":
+        return ComposeT([ClipT([target_variable]), LogT([target_variable]), UnitRangeT([target_variable]), RecentreT([target_variable])])
+    if key == "stanurrecen":
+        return ComposeT([Standardize([target_variable]), UnitRangeT([target_variable]), RecentreT([target_variable])])
+    if key == "stanmmrecen":
+        return ComposeT([Standardize([target_variable]), MinMax([target_variable]), RecentreT([target_variable])])
+    if key == "urrecen":
+        return ComposeT([UnitRangeT([target_variable]), RecentreT([target_variable])])
+    if key == "mmrecen":
+        return ComposeT([MinMax([target_variable]), RecentreT([target_variable])])
+    if key == "pcrecen":
+        return ComposeT([PercentToPropT([target_variable]), RecentreT([target_variable])])
+    if key == "recen":
+        return ComposeT([RecentreT([target_variable])])
+    xfms = [get_transform(name)([target_variable]) for name in key.split(";")]
+    return ComposeT(xfms)

--- a/src/zarr_data/utils.py
+++ b/src/zarr_data/utils.py
@@ -1,0 +1,15 @@
+from typing import Iterable, List
+
+
+def input_to_list(value) -> List:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Iterable):
+        return list(value)
+    return [value]

--- a/utils/inference_utils.py
+++ b/utils/inference_utils.py
@@ -7,8 +7,13 @@ def get_model_output(model_type, model, loaded_data, sampler = None, num_diffusi
         ts_ns = loaded_data[2]
         return test1, ts_ns
     elif model_type=='ldm':
-        low_res = loaded_data[0]     
-        static = loaded_data[2]
+        low_res = loaded_data[0]
+        if len(loaded_data) >= 4:
+            static = loaded_data[2]
+            ts_ns = loaded_data[3]
+        else:
+            static = torch.zeros_like(low_res)
+            ts_ns = loaded_data[2]
         # Generate residual and endode it!
         with torch.no_grad():
             residual, _ = model.autoencoder.preprocess_batch([ld.to(device='cuda:0') for ld in loaded_data[:-1]])
@@ -24,11 +29,9 @@ def get_model_output(model_type, model, loaded_data, sampler = None, num_diffusi
         # Run decoder to get estimate of high-res in pixel space
         with torch.no_grad():
             decoded_data = model.autoencoder.decode(test1).cpu()
-        # Get reference timestep
-        ts_ns = loaded_data[3]
         if model.autoencoder.ae_flag == 'residual':
             # Add back the unet results to the decoded residual
-            low_res_nn_merged_with_satic = model.autoencoder.nn_lr_and_merge_with_static(loaded_data[0],loaded_data[2])
+            low_res_nn_merged_with_satic = model.autoencoder.nn_lr_and_merge_with_static(low_res, static)
             with torch.no_grad():
                 result = decoded_data + model.autoencoder.unet(low_res_nn_merged_with_satic.to(device='cuda:0')).cpu()
             return result, ts_ns


### PR DESCRIPTION
### Motivation
- Provide a simple, self-contained zarr data pipeline so the latent-diffusion training/inference path can consume user-supplied .zarr datasets without the old dataloading/transform scaffolding. 
- Expose per-variable transforms and time-channel handling for zarr inputs so training/inference apply the same preprocessing when needed.

### Description
- Add a new `src/zarr_data` package implementing a zarr-backed data pipeline: `data_module.py` (Lightning `ZarrDataModule`), `dataset.py` (`DownscalingDataset`), `collate_np.py` (`FastCollate` handling dict-based batches and per-variable transforms), `transforms_np.py` (per-variable transform builders, save/load and many NumPy-friendly transforms), `get_xr_dataset.py`, `data_utils.py` (path helpers and `decode_zarr_time_array`), and small `utils.py` helpers. 
- Add a Hydra config `configs/data/zarr_data.yaml` and switch training defaults in `configs/train.yaml` to use the new datamodule by default. 
- Make model/inference code tolerant of batches without static conditioning: update `src/models/ae_module.py`, `src/models/ldm_module.py`, and `utils/inference_utils.py` to accept batches with or without the static conditioning/time element and to provide sensible defaults (zero tensors) when static inputs are absent. 
- Implement robust per-variable transform support (build/load pickled transforms, broadcast helpers, pixel- and global-standardization, clipping, root/log/minmax, compose, etc.) and zarr time decoding for CF-style units. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697358fb8b5c83249b7fa36b94128604)