### PR TITLE
feat: load DERIVED_DATA and WORK_DIR from .env for private path config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to .env and fill in your local paths.
+# .env is listed in .gitignore so your real paths stay private.
+
+# [required] Root path where datasets are stored.
+# Training data will be read from:  DERIVED_DATA/dataset_name/train.zarr
+# Validation data will be read from: DERIVED_DATA/dataset_name/val.zarr
+DERIVED_DATA=/path/to/data
+
+# [required] Root path for model outputs (checkpoints, transforms, logs, samples).
+# Should have at least ~10 GB of free space.
+WORK_DIR=/path/to/work_dir

--- a/configs/data/zarr_data.yaml
+++ b/configs/data/zarr_data.yaml
@@ -1,18 +1,21 @@
 _target_: src.zarr_data.data_module.ZarrDataModule
 
 # Root folder that contains <dataset_name>/<filename>
+# Resolves to the DERIVED_DATA environment variable from your .env file
 data_root: ${paths.data_dir}
 
-# Dataset folder name and zarr file name
-# Override these from the command line for your dataset.
+# Dataset folder name and zarr file names
+# Override dataset_name from the command line or experiment config.
+# Paths will be: DERIVED_DATA/dataset_name/train.zarr  and  DERIVED_DATA/dataset_name/val.zarr
 dataset_name: ERA5_IMERG_Med_192x192_2000-2024
-filename: data.zarr
-val_filename: null
+filename: train.zarr
+val_filename: val.zarr
 
 # Optional dataset names used to fit transforms (defaults to dataset_name)
 model_src_dataset_name: UKCP_Local
 input_transform_dataset_name: UKCP_Local
-transform_dir: null
+# Directory to cache fitted transforms; resolves to WORK_DIR/transforms from your .env file
+transform_dir: ${paths.work_dir_root}/transforms
 
 batch_size: 4
 num_workers: 0

--- a/configs/paths/default.yaml
+++ b/configs/paths/default.yaml
@@ -3,19 +3,24 @@
 # you can replace it with "." if you want the root to be the current working directory
 root_dir: ${oc.env:PROJECT_ROOT}
 
-# path to data directory
-data_dir: ${paths.root_dir}/data/
+# [required] root path for datasets — set DERIVED_DATA in your .env file
+# datasets are expected at: data_dir/dataset_name/train.zarr (and val.zarr)
+data_dir: ${oc.env:DERIVED_DATA}
+
+# [required] root path for model checkpoints, transforms, samples, etc.
+# set WORK_DIR in your .env file — should have at least ~10 GB free
+work_dir_root: ${oc.env:WORK_DIR}
 
 # path to logging directory
-log_dir: ${paths.root_dir}/logs/
+log_dir: ${paths.work_dir_root}/logs/
 
 # path to output directory, created dynamically by hydra
 # path generation pattern is specified in `configs/hydra/default.yaml`
 # use it to store all files generated during the run, like ckpts and metrics
 output_dir: ${hydra:runtime.output_dir}
 
-# path to working directory
-work_dir: ${hydra:runtime.cwd}
+# path to current working directory (where you run the training command)
+cwd: ${hydra:runtime.cwd}
 
 # path to pretrained_models:
 pretrained_models_dir: ${paths.root_dir}/pretrained_models/

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ hydra-optuna-sweeper==1.2.0
 # aim>=3.16.2  # no lower than 3.16.2, see https://github.com/aimhubio/aim/issues/2550
 
 # --------- others --------- #
+python-dotenv   # loading .env files for private path configuration
 pyrootutils     # standardizing the project root setup
 pre-commit      # hooks for applying linters on commit
 rich            # beautiful text formatting in terminal

--- a/src/train.py
+++ b/src/train.py
@@ -4,6 +4,7 @@ import hydra
 import lightning as L
 import pyrootutils
 import torch
+from dotenv import load_dotenv
 from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
@@ -25,6 +26,10 @@ pyrootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 #
 # more info: https://github.com/ashleve/pyrootutils
 # ------------------------------------------------------------------------------------ #
+
+# Explicitly load .env so DERIVED_DATA and WORK_DIR are available before Hydra
+# resolves the config (override=False keeps any variables already set in the shell)
+load_dotenv(override=False)
 
 from src import utils
 


### PR DESCRIPTION
- Add python-dotenv to requirements.txt
- Update configs/paths/default.yaml: data_dir now reads from DERIVED_DATA env var, work_dir_root reads from WORK_DIR env var, log_dir moved under work_dir_root
- Update configs/data/zarr_data.yaml: default filenames changed to train.zarr / val.zarr, transform_dir set to WORK_DIR/transforms
- Add explicit load_dotenv() call in src/train.py (before Hydra resolves config so env vars are available)
- Add .env.example template showing required variables

Dataset paths resolve as: DERIVED_DATA/dataset_name/train.zarr and DERIVED_DATA/dataset_name/val.zarr

Closes #4