### PR TITLE
feat: configure model checkpoint path as WORK_DIR/dataset_name/experi…

### DIFF
--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -6,13 +6,13 @@ defaults:
   - _self_
 
 model_checkpoint:
-  dirpath: ${paths.output_dir}/checkpoints
-  filename: "epoch_{epoch:03d}"
+  dirpath: ${paths.ckpt_dir}
+  filename: "epoch={epoch}-val_loss={val/loss:.4f}"
   monitor: "val/loss"
   mode: "min"
   save_last: True
   auto_insert_metric_name: False
-  save_top_k: 3
+  save_top_k: -1
 
 early_stopping:
   monitor: "val/loss"

--- a/configs/paths/default.yaml
+++ b/configs/paths/default.yaml
@@ -24,3 +24,10 @@ cwd: ${hydra:runtime.cwd}
 
 # path to pretrained_models:
 pretrained_models_dir: ${paths.root_dir}/pretrained_models/
+
+# experiment name for organizing checkpoints
+# override this in your experiment config or via command line: paths.experiment_name=my_run
+experiment_name: "default_experiment"
+
+# path to save model checkpoints: WORK_DIR/dataset_name/experiment_name/
+ckpt_dir: ${paths.work_dir_root}/${data.dataset_name}/${paths.experiment_name}


### PR DESCRIPTION
…ment_name/

- Add `experiment_name` variable to configs/paths/default.yaml (default: "default_experiment") Users can override via command line (paths.experiment_name=my_run) or experiment config
- Add `ckpt_dir` path: ${paths.work_dir_root}/${data.dataset_name}/${paths.experiment_name}
- Update ModelCheckpoint in configs/callbacks/default.yaml:
  - dirpath: ${paths.ckpt_dir} (saves to WORK_DIR/dataset_name/experiment_name/)
  - filename: "epoch={epoch}-val_loss={val/loss:.4f}" (e.g. epoch=4-val_loss=0.1234.ckpt)
  - save_top_k: -1 (save ALL checkpoints)

Closes #6